### PR TITLE
blake3: support arbitrary flags

### DIFF
--- a/blake3/blake3.c
+++ b/blake3/blake3.c
@@ -391,6 +391,12 @@ void blake3_hasher_init_derive_key(blake3_hasher *self, const char *context) {
   blake3_hasher_init_derive_key_raw(self, context, strlen(context));
 }
 
+void blake3_hasher_init_raw(blake3_hasher *self, const uint8_t key[BLAKE3_KEY_LEN], uint8_t flags) {
+  uint32_t key_words[8];
+  load_key_words(key, key_words);
+  hasher_init_base(self, key_words, flags);
+}
+
 // As described in hasher_push_cv() below, we do "lazy merging", delaying
 // merges until right before the next CV is about to be added. This is
 // different from the reference implementation. Another difference is that we

--- a/blake3/blake3.h
+++ b/blake3/blake3.h
@@ -61,6 +61,8 @@ typedef struct {
 } blake3_hasher;
 
 BLAKE3_API const char *blake3_version(void);
+BLAKE3_API void blake3_hasher_init_raw(blake3_hasher *self, const uint8_t key[BLAKE3_KEY_LEN],
+                                       uint8_t flags);
 BLAKE3_API void blake3_hasher_init(blake3_hasher *self);
 BLAKE3_API void blake3_hasher_init_keyed(blake3_hasher *self,
                                          const uint8_t key[BLAKE3_KEY_LEN]);

--- a/urcrypt/blake3.c
+++ b/urcrypt/blake3.c
@@ -7,15 +7,12 @@ void
 urcrypt_blake3_hash(size_t message_length,
                     uint8_t *message,
                     uint8_t key[BLAKE3_KEY_LEN],
+                    uint8_t flags,
                     size_t out_length,
                     uint8_t *out)
 {
   blake3_hasher hasher;
-  if (memcmp(key, IV, 32) == 0) {
-    blake3_hasher_init(&hasher);
-  } else {
-    blake3_hasher_init_keyed(&hasher, key);
-  }
+  blake3_hasher_init_raw(&hasher, key, flags);
   blake3_hasher_update(&hasher, message, message_length);
   blake3_hasher_finalize(&hasher, out, out_length);
 }

--- a/urcrypt/urcrypt.h
+++ b/urcrypt/urcrypt.h
@@ -178,6 +178,7 @@ int urcrypt_blake2(size_t message_length,
 void urcrypt_blake3_hash(size_t message_length,
                          uint8_t *message,
                          uint8_t key[32],
+                         uint8_t flags,
                          size_t out_length,
                          uint8_t *out);
 


### PR DESCRIPTION
This is necessary for using BLAKE3 as a KDF. (Currently, if you try to set `f-derivekeyctx`, the jet just ignores it.) The old approach of comparing the key to IV was busted anyway.