### PR TITLE
Add secp256k1_scalar_to_point jet

### DIFF
--- a/urcrypt/secp256k1.c
+++ b/urcrypt/secp256k1.c
@@ -243,3 +243,32 @@ urcrypt_secp_schnorr_veri(urcrypt_secp_context* context,
   }
   return true;
 }
+
+int
+urcrypt_secp_point_from_scalar(urcrypt_secp_context* context,
+                                const uint8_t scalar[32],
+                                uint8_t point[65]) {
+  urcrypt__reverse(32, scalar);
+  secp256k1_keypair keypair;
+  secp256k1_pubkey pubkey;
+
+  secp256k1_keypair_create(context->secp, &keypair, scalar);
+
+  secp256k1_keypair_pub(context->secp, &pubkey, &keypair);
+
+  size_t output_len = 65;
+  if (1 != secp256k1_ec_pubkey_serialize(
+          context->secp,
+          point,
+          &output_len,
+          &pubkey,
+          SECP256K1_FLAGS_TYPE_COMPRESSION)) {
+    return -1;
+  }
+
+  urcrypt__reverse(32, point + 1);
+  urcrypt__reverse(32, point + 33);
+
+  return 0;
+}
+

--- a/urcrypt/urcrypt.h
+++ b/urcrypt/urcrypt.h
@@ -284,9 +284,17 @@ void urcrypt_scrypt_pbkdf_sha256(const uint8_t *passwd,
                                  size_t outlen, // must be at most 32*(2^32-1)
                                  uint8_t *out);
 
-int urcrypt_secp_point_from_scalar(urcrypt_secp_context* context,
-                                const uint8_t scalar[32],
-                                uint8_t point[65]);
+int urcrypt_secp_cmp_point_from_scalar(urcrypt_secp_context* context,
+                                   const uint8_t scalar[32],
+                                   uint8_t cmp_point[33]);
+
+int urcrypt_secp_scalar_tweak_add(urcrypt_secp_context* context,
+                                  uint8_t scalar[32],
+                                  const uint8_t tweak[32]);
+
+int urcrypt_secp_cmp_point_tweak_add(urcrypt_secp_context* context,
+                                  uint8_t cmp_point[33],
+                                  const uint8_t tweak[32]);
 
 int urcrypt_scrypt(const uint8_t *passwd,
                    size_t passwdlen,

--- a/urcrypt/urcrypt.h
+++ b/urcrypt/urcrypt.h
@@ -284,6 +284,10 @@ void urcrypt_scrypt_pbkdf_sha256(const uint8_t *passwd,
                                  size_t outlen, // must be at most 32*(2^32-1)
                                  uint8_t *out);
 
+int urcrypt_secp_point_from_scalar(urcrypt_secp_context* context,
+                                const uint8_t scalar[32],
+                                uint8_t point[65]);
+
 int urcrypt_scrypt(const uint8_t *passwd,
                    size_t passwdlen,
                    const uint8_t *salt,


### PR DESCRIPTION
Jets `secp256k1_scalar_to_point` to make building, signing, and spending taproot transactions faster. Making these transactions faster to build and verify also improves their security posture. This PR also enables optional tweaks to private keys and compressed pubkeys.